### PR TITLE
turns on project settings>display>window>allow hidpi

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -24,6 +24,10 @@ config/name="CreatureTD"
 run/main_scene="res://gameRoot.tscn"
 config/icon="res://icon.png"
 
+[display]
+
+window/dpi/allow_hidpi=true
+
 [gdnative]
 
 singletons=[ "res://addons/godot-git-plugin/git_api.gdnlib" ]


### PR DESCRIPTION
This is needed for some screens so the game loads at the correct size + position on screen (including mine).

With this off it appears off screen in editor, and opens up larger than intended in windows export.

Happy to see you started this btw, PTD used to be so fun 10 years ago!